### PR TITLE
Use env variable to pass options to dmenu

### DIFF
--- a/=
+++ b/=
@@ -29,7 +29,7 @@ esac
 if [[ -n $(command -v rofi) ]]; then
     menu="$(command -v rofi) -dmenu -lines 3 ""$@"
 elif [[ -n $(command -v dmenu) ]]; then
-    menu="$(command -v dmenu) ""$@"
+    menu="$(command -v dmenu) ""$DMENU_OPTIONS"
 else
     echo >&2 "Rofi or dmenu not found"
     exit


### PR DESCRIPTION
This PR fixes a problem when using menu-calc with dmenu.

dmenu takes its values from stdin, not command-line arguments. But menu-calc gives, via `$@`, bad arguments to dmenu in the case the script is executed with an initial calculus, like `= 1+1`.

This patch removes `$@` to avoid the problem described, and reads a `$DMENU_OPTIONS` environment variable in order to pass options to dmenu, like: `DMENU_OPTIONS="-l 10" = 1+1`.

By the way thanks to all the *many* forkers of menu-calc :wink: 