### PR TITLE
Fix to have height option (-h) correctly pass to dmenu

### DIFF
--- a/=
+++ b/=
@@ -40,6 +40,7 @@ do
         -d=*|--dmenu=*)
             menu=$(echo $var | cut -d'=' -f 2);
             ;;
+        --) break ;;
     esac
 done
 


### PR DESCRIPTION
-h help menu-calc option was overlapping -h height demnu option