### PR TITLE
make install, README mention and separate headers from paragraphs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,24 @@
+PREFIX = /usr/local
+MANPREFIX = ${PREFIX}/share/man
+
+all: install
+
+install:
+	mkdir -p ${DESTDIR}${PREFIX}/bin
+	cp -f = ${DESTDIR}${PREFIX}/bin
+	chmod 755 ${DESTDIR}${PREFIX}/bin/=
+	mkdir -p ${DESTDIR}${MANPREFIX}/man1
+	cp -f =.1 ${DESTDIR}${MANPREFIX}/man1
+	cp -f menu-calc.1 ${DESTDIR}${MANPREFIX}/man1
+	chmod 644 ${DESTDIR}${MANPREFIX}/man1/=.1
+	chmod 644 ${DESTDIR}${MANPREFIX}/man1/menu-calc.1
+
+uninstall:
+	rm -f ${DESTDIR}${PREFIX}/bin/=
+	rm -f ${DESTDIR}${MANPREFIX}/man1/=.1
+	rm -f ${DESTDIR}${MANPREFIX}/man1/menu-calc.1
+
 test:
 	man -l doc/menu-calc.1
+
+.PHONY: all install uninstall test

--- a/README.md
+++ b/README.md
@@ -1,18 +1,30 @@
 # menu-calc
+
 A calculator for Rofi/dmenu(2)
 
 [Screencast](https://gfycat.com/SociableDopeyHerald)
 
 ## Installation
-Arch Linux AUR: [menu-calc](https://aur.archlinux.org/packages/menu-calc/)
+
+### GNU make
+
+```sh
+sudo make install
+```
+
+### Arch Linux AUR
+
+[menu-calc](https://aur.archlinux.org/packages/menu-calc/)
 
 ## Dependencies
+
 - [bc](https://www.archlinux.org/packages/extra/x86_64/bc/)
 - [xclip](https://www.archlinux.org/packages/extra/x86_64/xclip/)
 - [Rofi](https://aur.archlinux.org/packages/rofi-git/) or
   dmenu[(2)](https://aur.archlinux.org/packages/dmenu2/)
 
 ## Usage
+
 `menu-calc` uses `bc` as the backend and will accept any operations `bc` is able
 to do:
 
@@ -29,6 +41,7 @@ inside (or outside) Rofi/dmenu.
 If launched outside of Rofi/dmenu the expression may need quotation marks.
 
 ## Custom Usage
+
 To launch directly into the calculator, use the following command (useful if
 bound to "super + equal" in [sxhkd](https://github.com/baskerville/sxhkd),
 [i3](https://i3wm.org/) or the like):
@@ -40,6 +53,7 @@ For example:
     = -- -location 2 -width 100
 
 ### Force usage of `dmenu`
+
 By default, if `rofi` is installed, it will be used. You can force `menu-calc`
 to use `dmenu` or any other `dmenu`-like application:
 


### PR DESCRIPTION
Added make targets `install` and `uninstall` which install and uninstall menu-calc on traditional directory structure (`/usr/local/bin`, `/usr/local/share/man`). Running make without parameters runs the installation target. The root of installation can be changed from `/` by exporting DESTDIR env var (`DESTDIR=~/menu-calc make install` creates `~/menu-calc/` and uses it as the root of installation).

Added a mention about the new way to install with make in the `README.md`.

This allows non-AUR users to easily (un)install the shell script and man pages.

Made `README.md` headers be separate from paragraphs by 2 new lines for readability and it's the more common way I've seen it. No visual change on Github AFAIK.